### PR TITLE
SSH key managment

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ The Emacs SSH Machines Management Tool is designed to simplify the management of
 - **List SSH Machines:** Displays a neatly formatted list of all configured SSH machines in an Emacs buffer, providing a quick overview of available connections.
 - **Connect to SSH Machines:** Enables users to connect to a selected SSH machine using the SSH protocol directly from Emacs, facilitating seamless remote work.
 - **Copy Files to remote:** Users can easily copy files from their local machine to the remote machine.
+- **SSH Key Management:** Manage your SSH keys directly from Emacs, including viewing, generating, and associating keys with specific servers.
 
 ## Installation
 
@@ -52,6 +53,33 @@ Use `M-x ssh-connect` and select the desired SSH machine to establish an SSH con
 ### Copying a file to an SSH Machine
 
 To copy a file from your local machine to the remote one, use `M-x copy-file-to-ssh-machine`. You will be prompted to select the file to copy, the target machin, and the remote destination path.
+
+### Managing SSH Keys
+
+The SSH Machines Management Tool now includes comprehensive SSH key management features:
+
+#### Viewing SSH Keys
+
+Use `M-x ssh-list-keys` to display all your SSH keys in a buffer. This will show:
+- The names of your key files
+- Whether each key has a corresponding public key
+- Associated comments (typically email addresses)
+
+#### Generating SSH Keys
+
+Execute `M-x ssh-generate-key` to create a new SSH key pair. You will be prompted for:
+- Key type (RSA, Ed25519, ECDSA, or DSA)
+- Key name (filename)
+- Key comment (typically your email address)
+- For RSA keys, you can specify the bit length (2048 or 4096)
+
+#### Copying SSH Keys to Remote Servers
+
+Use `M-x ssh-copy-key` to copy a public key to a remote server. This simplifies the process of setting up key-based authentication.
+
+#### Associating Keys with Specific Servers
+
+Execute `M-x ssh-associate-key-with-machine` to link a specific SSH key with a server in your machines list. When you connect to this server using `M-x ssh-connect`, the associated key will be used automatically.
 
 ## Configuration
 

--- a/init-ssh.el
+++ b/init-ssh.el
@@ -5,7 +5,7 @@
 (require 'cl-seq)
 
 (defcustom ssh-copy-method 'scp
-  "Method to use for copying files to remote machines. Can be either 'scp or 'rsync."
+  "Method to use for copying files to remote machines.  Can be either 'scp or 'rsync."
   :type '(choice (const scp) (const rsync))
   :group 'ssh-machines)
 
@@ -75,7 +75,7 @@
   (message "Imported SSH machines from %s" file-path))
 
 (defun copy-file-to-ssh-machine (file-path)
-  "Copy a file from the host machine to a selected remote SSH machine."
+  "Copy a file via FILE-PATH from the host machine to a selected remote SSH machine."
   (interactive "fFile to copy: ")
   (let* ((machine-names (mapcar #'car (multisession-value ssh-machines-list)))
 	 (selected-name (completing-read "Select target machine: " machine-names))
@@ -148,7 +148,7 @@ KEY-COMMENT is typically your email address for identification."
 	(async-shell-command command "*SSH Key Generation*")))))
 
 (defun ssh-copy-key (key-file)
-  "Copy an SSH public key to a remote machine."
+  "Copy an SSH public key (KEY-FILE) to a remote machine."
   (interactive
    (list (completing-read "Select key to copy: "
 			  (cl-remove-if


### PR DESCRIPTION
This commit adds SSH key management capabilities:

- Adds ability to view and list all SSH keys in ~/.ssh directory
- Implements SSH key generation with support for RSA, Ed25519, ECDSA,
  and DSA
- Adds functionality to copy SSH keys to remote machines with
  ssh-copy-id
- Allows associating specific SSH keys with machines in your list
- Updates ssh-connect to automatically use associated keys when
  connecting
- Updates README with documentation for all new SSH key management
  features

These changes significantly enhance the tool by creating a more
complete SSH workflow directly within Emacs. Users can now manage
their entire SSH experience from key generation to connection in one
place.