### PR TITLE
init-ssh: fix void function error for multisession-make

### DIFF
--- a/init-ssh.el
+++ b/init-ssh.el
@@ -3,14 +3,14 @@
 ;;; Code:
 
 (require 'cl-lib)
+(require 'multisession)
 
 (defgroup ssh-machines nil
   "SSH machines management."
   :group 'tools
   :prefix "ssh-")
 
-(defvar ssh-machines-list
-  (multisession-make '())
+(define-multisession-variable ssh-machines-list '()
   "A list of SSH machines to connect to.
 Each element is a list (NAME ADDRESS DESCRIPTION [KEY-FILE]).
 NAME is the name of the machine.


### PR DESCRIPTION
multisession-make does not exist in the Emacs multisession API.  The correct interface is define-multisession-variable, which expands to a defvar backed by make-multisession internally.

Replace the broken defvar + multisession-make call with define-multisession-variable and add the missing
(require 'multisession) dependency.